### PR TITLE
[Feat] 응답 핸들러 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/TubeSlice/tubeSlice/global/response/ApiResponse.java
+++ b/src/main/java/TubeSlice/tubeSlice/global/response/ApiResponse.java
@@ -1,0 +1,38 @@
+package TubeSlice.tubeSlice.global.response;
+
+import TubeSlice.tubeSlice.global.response.code.BaseCode;
+import TubeSlice.tubeSlice.global.response.code.resultCode.SuccessStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class ApiResponse<T> {
+
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+    private final String code;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T result;
+
+
+    // 성공한 경우 응답 생성
+    public static <T> ApiResponse<T> onSuccess(T result){
+        return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
+    }
+
+    public static <T> ApiResponse<T> of(BaseCode code, T result){
+            return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
+    }
+
+
+    // 실패한 경우 응답 생성
+    public static <T> ApiResponse<T> onFailure(String code, String message, T data){
+        return new ApiResponse<>(false, code, message, data);
+    }
+}

--- a/src/main/java/TubeSlice/tubeSlice/global/response/code/BaseCode.java
+++ b/src/main/java/TubeSlice/tubeSlice/global/response/code/BaseCode.java
@@ -1,0 +1,7 @@
+package TubeSlice.tubeSlice.global.response.code;
+
+public interface BaseCode {
+    public ReasonDto getReason();
+
+    public ReasonDto getReasonHttpStatus();
+}

--- a/src/main/java/TubeSlice/tubeSlice/global/response/code/BaseErrorCode.java
+++ b/src/main/java/TubeSlice/tubeSlice/global/response/code/BaseErrorCode.java
@@ -1,0 +1,7 @@
+package TubeSlice.tubeSlice.global.response.code;
+
+public interface BaseErrorCode {
+    public ErrorReasonDto getReason();
+
+    public ErrorReasonDto getReasonHttpStatus();
+}

--- a/src/main/java/TubeSlice/tubeSlice/global/response/code/ErrorReasonDto.java
+++ b/src/main/java/TubeSlice/tubeSlice/global/response/code/ErrorReasonDto.java
@@ -1,0 +1,17 @@
+package TubeSlice.tubeSlice.global.response.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ErrorReasonDto {
+    private HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public boolean getIsSuccess(){return isSuccess;}
+}

--- a/src/main/java/TubeSlice/tubeSlice/global/response/code/ReasonDto.java
+++ b/src/main/java/TubeSlice/tubeSlice/global/response/code/ReasonDto.java
@@ -1,0 +1,18 @@
+package TubeSlice.tubeSlice.global.response.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ReasonDto {
+
+    private HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public boolean getIsSuccess(){return isSuccess;}
+}

--- a/src/main/java/TubeSlice/tubeSlice/global/response/code/resultCode/ErrorStatus.java
+++ b/src/main/java/TubeSlice/tubeSlice/global/response/code/resultCode/ErrorStatus.java
@@ -1,0 +1,42 @@
+package TubeSlice.tubeSlice.global.response.code.resultCode;
+
+
+import TubeSlice.tubeSlice.global.response.code.BaseErrorCode;
+import TubeSlice.tubeSlice.global.response.code.ErrorReasonDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+    // Global
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "GLOBAL401", "서버 오류"),
+    KAKAO_TOKEN_ERROR(HttpStatus.BAD_REQUEST, "GLOBAL402", "토큰관련 서버 에러"),
+
+    // User
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER401", "해당 유저가 존재하지 않습니다." );
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDto getReason() {
+        return ErrorReasonDto.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDto getReasonHttpStatus() {
+        return ErrorReasonDto.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/TubeSlice/tubeSlice/global/response/code/resultCode/SuccessStatus.java
+++ b/src/main/java/TubeSlice/tubeSlice/global/response/code/resultCode/SuccessStatus.java
@@ -1,0 +1,39 @@
+package TubeSlice.tubeSlice.global.response.code.resultCode;
+
+import TubeSlice.tubeSlice.global.response.code.BaseCode;
+import TubeSlice.tubeSlice.global.response.code.ReasonDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+
+    _OK(HttpStatus.OK, "COMMON200", "성공입니다.");
+
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDto getReason() {
+        return ReasonDto.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .build();
+    }
+
+    @Override
+    public ReasonDto getReasonHttpStatus() {
+        return ReasonDto.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/TubeSlice/tubeSlice/global/response/exception/ExceptionAdvice.java
+++ b/src/main/java/TubeSlice/tubeSlice/global/response/exception/ExceptionAdvice.java
@@ -1,0 +1,99 @@
+package TubeSlice.tubeSlice.global.response.exception;
+
+import TubeSlice.tubeSlice.global.response.ApiResponse;
+import TubeSlice.tubeSlice.global.response.code.ErrorReasonDto;
+import TubeSlice.tubeSlice.global.response.code.resultCode.ErrorStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class})
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(constraintViolation -> constraintViolation.getMessage())
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("ConstraintViolationException 추출 도중 에러 발생"));
+
+        return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY,request);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        e.printStackTrace();
+
+        return handleExceptionInternalFalse(e, ErrorStatus.INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY, ErrorStatus.INTERNAL_SERVER_ERROR.getHttpStatus(),request, e.getMessage());
+    }
+
+    @ExceptionHandler(value = GeneralException.class)
+    public ResponseEntity onThrowException(GeneralException generalException, HttpServletRequest request) {
+        ErrorReasonDto errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+        return handleExceptionInternal(generalException,errorReasonHttpStatus,null,request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorReasonDto reason,
+                                                           HttpHeaders headers, HttpServletRequest request) {
+
+        ApiResponse<Object> body = ApiResponse.onFailure(reason.getCode(),reason.getMessage(),null);
+//        e.printStackTrace();
+
+        WebRequest webRequest = new ServletWebRequest(request);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                reason.getHttpStatus(),
+                webRequest
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorCommonStatus,
+                                                                HttpHeaders headers, HttpStatus status, WebRequest request, String errorPoint) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorPoint);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                status,
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers, ErrorStatus errorCommonStatus,
+                                                               WebRequest request, Map<String, String> errorArgs) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorArgs);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorCommonStatus,
+                                                                     HttpHeaders headers, WebRequest request) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), null);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+}

--- a/src/main/java/TubeSlice/tubeSlice/global/response/exception/GeneralException.java
+++ b/src/main/java/TubeSlice/tubeSlice/global/response/exception/GeneralException.java
@@ -1,0 +1,22 @@
+package TubeSlice.tubeSlice.global.response.exception;
+
+
+import TubeSlice.tubeSlice.global.response.code.BaseErrorCode;
+import TubeSlice.tubeSlice.global.response.code.ErrorReasonDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+
+    private BaseErrorCode code;
+
+    public ErrorReasonDto getErrorReason() {
+        return this.code.getReason();
+    }
+
+    public ErrorReasonDto getErrorReasonHttpStatus(){
+        return this.code.getReasonHttpStatus();
+    }
+}

--- a/src/main/java/TubeSlice/tubeSlice/global/response/exception/GeneralException.java
+++ b/src/main/java/TubeSlice/tubeSlice/global/response/exception/GeneralException.java
@@ -10,13 +10,13 @@ import lombok.Getter;
 @AllArgsConstructor
 public class GeneralException extends RuntimeException {
 
-    private BaseErrorCode code;
+    private BaseErrorCode errorCode;
 
     public ErrorReasonDto getErrorReason() {
-        return this.code.getReason();
+        return this.errorCode.getReason();
     }
 
     public ErrorReasonDto getErrorReasonHttpStatus(){
-        return this.code.getReasonHttpStatus();
+        return this.errorCode.getReasonHttpStatus();
     }
 }

--- a/src/main/java/TubeSlice/tubeSlice/global/response/exception/handler/UserHandler.java
+++ b/src/main/java/TubeSlice/tubeSlice/global/response/exception/handler/UserHandler.java
@@ -1,0 +1,11 @@
+package TubeSlice.tubeSlice.global.response.exception.handler;
+
+import TubeSlice.tubeSlice.global.response.code.BaseErrorCode;
+import TubeSlice.tubeSlice.global.response.exception.GeneralException;
+
+public class UserHandler extends GeneralException {
+
+    public UserHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}


### PR DESCRIPTION
# 구현 사항
---
(저번 워크북을 봤다면 거기서 나오는 응답 핸들러입니다.)

## ErrorReasonDto

- 에러기준으로 설명하자면 프론트에게 응답을 보낼 때, 기본적으로 제공하는 응답이 아닌 따로 응답을 설정하는 과정입니다. 성공여부, code, message를 변수로 
```java
public class ErrorReasonDto {
    private HttpStatus httpStatus;

    private final boolean isSuccess;
    private final String code;
    private final String message;
}
```

</br>

- 개념이 어려우니 자세한 작동 방식은 나중에 공부하고 사용법 먼저 알려드리겠습니다.

## 사용법

- 만약 유저관련 error를 만들고 싶다! (유저가 존재하지 않습니다. -> 주로 userId로 repository를 확인하는데 존재하지 않을 때 발생시키는 응답)
- exception > handler에서 UserHandler 존재 확인 없다면 생성 (엔티티명 + Handler)
- GeneralException을 상속받은 후 오류난 부분에 alt + enter 하면 아래와 같은 코드가 작성됩니다. 변수명 
```java
public class UserHandler extends GeneralException {

    public UserHandler(BaseErrorCode errorCode) {
        super(errorCode);
    }
}
```
- 후에 필요한 응답 코드를 ErrorStatus에 저장

```java
// User
USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER401", "해당 유저가 존재하지 않습니다." );
```

enum class로 enum명은 대문자로만 작성합니다.
(HttpStatus, "code" , "message") 형식입니다. 이는 프론트에게 제공될 값입니다.

</br>

- 추가 후 사용은 아래와 같이 작성해주시면 됩니다.

```java
User user = userRespository.findById(userId).orElseThrow(()->new UserHandler(ErrorStatus.USER_NOT_FOUND));
```

