### PR TITLE
[Setting] swagger 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	//swagger
+	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.0.3'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/TubeSlice/tubeSlice/domain/oauth/CustomOauth2UserService.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/oauth/CustomOauth2UserService.java
@@ -28,9 +28,9 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
 
         OAuth2User oAuth2User = super.loadUser(userRequest);
-        String acessToken = userRequest.get().getTokenValue();
+        String accessToken = userRequest.getAccessToken().getTokenValue();
 
-        log.info("OAuth2User loadUser access_token: {}", acessToken);
+        log.info("OAuth2User loadUser access_token: {}", accessToken);
 
         String provider = userRequest.getClientRegistration().getRegistrationId();  //naver/kakao
 

--- a/src/main/java/TubeSlice/tubeSlice/domain/oauth/OauthController.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/oauth/OauthController.java
@@ -3,6 +3,10 @@ package TubeSlice.tubeSlice.domain.oauth;
 import TubeSlice.tubeSlice.domain.oauth.dto.response.LoginResponseDto;
 import TubeSlice.tubeSlice.domain.user.UserService;
 import TubeSlice.tubeSlice.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -17,6 +21,11 @@ public class OauthController {
     private final OauthService userService;
 
     @PostMapping("/login")
+    @Operation(summary = "로그인 API", description = "로그인 후 accessToken 전송, LoginResponseDto 이용")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER401", description = "유저가 존재하지 않습니다",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
     public ApiResponse<LoginResponseDto> socialLogin(@RequestHeader(name = "access_token") String access_token,
                                                      @RequestHeader(name = "social_type") String social_type){
 

--- a/src/main/java/TubeSlice/tubeSlice/domain/oauth/dto/response/OauthResponseDto.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/oauth/dto/response/OauthResponseDto.java
@@ -1,0 +1,18 @@
+package TubeSlice.tubeSlice.domain.oauth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class OauthResponseDto {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TokenDto{
+        private String grantType;
+        private String accessToken;
+    }
+
+}

--- a/src/main/java/TubeSlice/tubeSlice/global/config/SecurityConfig.java
+++ b/src/main/java/TubeSlice/tubeSlice/global/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package TubeSlice.tubeSlice;
+package TubeSlice.tubeSlice.global.config;
 
 import TubeSlice.tubeSlice.global.filter.JwtAuthenticationFilter;
 import TubeSlice.tubeSlice.domain.oauth.OAuth2SuccessHandler;

--- a/src/main/java/TubeSlice/tubeSlice/global/config/SwaggerConfig.java
+++ b/src/main/java/TubeSlice/tubeSlice/global/config/SwaggerConfig.java
@@ -1,0 +1,40 @@
+package TubeSlice.tubeSlice.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI TubeSlice(){
+        Info info = new Info()
+                .title("Tube-Slice API")
+                .description("Tube-Slice API 명세서")
+                .version("1.0.0");
+
+        //jwt 토큰 이용하여 인증 설정
+        String jwtSchemeName = "JWT TOKEN";
+
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
+                        .type(SecurityScheme.Type.HTTP) // HTTP 방식
+                        .scheme("bearer")
+                        .bearerFormat("JWT"));
+
+        return new OpenAPI()
+                .addServersItem(new Server().url("/"))
+                .info(info)
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+}


### PR DESCRIPTION
# 구현 내용
---
## Swagger 관련 gradle

```
	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.0.3'
```

</br>

## OauthController

```java
public class OauthController {

    private final OauthService userService;

    @PostMapping("/login")
    @Operation(summary = "로그인 API", description = "로그인 후 accessToken 전송, LoginResponseDto 이용")
    @ApiResponses({
            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER401", description = "유저가 존재하지 않습니다",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
    })
    public ApiResponse<LoginResponseDto> socialLogin(@RequestHeader(name = "access_token") String access_token,
                                                     @RequestHeader(name = "social_type") String social_type){

        LoginResponseDto loginResponseDto = userService.getJwtTokenAndUserId(access_token, social_type);

        return ApiResponse.onSuccess(loginResponseDto);

    }
}
```

- 위와 같이 description에는 어떤 Dto를 활용하는지 말해주시면 프론트가 확인이 편하다고합니다.
- ApiResponse는 responseCode와 description도 다음과 같이 설정한 ApiResponse로 작성하면 됩니다.

</br>

- 만약 parameter값이 필요하다면

```java
    @Parameters({
            @Parameter(name = "nickname", description = "유저의 닉네임"),
    })
```

아래와 같이 작성해주시면 됩니다.

</br>

# 결과값

![image](https://github.com/Tube-Slice/Tube-Slice-BE/assets/119154537/1854dc7c-cccf-4ef4-9f4f-436cbb5287c1)

![image](https://github.com/Tube-Slice/Tube-Slice-BE/assets/119154537/c56dafee-0ab7-439f-9400-38f1a4e6b0ac)
