### PR TITLE
[Feat] 댓글 작성하기 / 삭제하기 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	//testImplementatiogn 'org.springframework.boot:spring-boot-starter-test'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	// jwt

--- a/src/main/java/TubeSlice/tubeSlice/domain/comment/CommentController.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/comment/CommentController.java
@@ -1,0 +1,57 @@
+package TubeSlice.tubeSlice.domain.comment;
+
+import TubeSlice.tubeSlice.domain.comment.dto.request.CommentRequestDto;
+import TubeSlice.tubeSlice.domain.comment.dto.response.CommentResponseDto;
+import TubeSlice.tubeSlice.domain.post.Post;
+import TubeSlice.tubeSlice.domain.post.PostService;
+import TubeSlice.tubeSlice.domain.user.User;
+import TubeSlice.tubeSlice.domain.user.UserService;
+import TubeSlice.tubeSlice.global.response.ApiResponse;
+import TubeSlice.tubeSlice.global.response.code.resultCode.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/comments")
+public class CommentController {
+    private final UserService userService;
+    private final PostService postService;
+    private final CommentService commentService;
+
+    @PostMapping("/posts/{postId}")
+    @Operation(summary = "댓글 작성하기 API",description = "post의 id를 받아 댓글을 생성한 후 comment의 id(CommentResultDto)를 반환")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER401", description = "댓글을 작성할 유저가 존재하지 않습니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "POST401", description = "댓글을 작성할 게시글이 존재하지 않습니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "postId", description = "댓글을 작성할 post의 id"),
+    })
+    public ApiResponse<CommentResponseDto.CommentResultDto> createComment(@PathVariable(name = "postId")Long postId, @RequestBody CommentRequestDto.CommentCreateDto request){
+        User user = userService.findUser(1L);
+        Post post = postService.findPost(postId);
+
+        return ApiResponse.onSuccess(commentService.createComment(request, user, post));
+    }
+
+    @DeleteMapping("/{commentId}")
+    @Operation(summary = "댓글 삭제하기 API",description = "삭제할 comment의 id를 받아 삭제")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMENT401", description = "삭제할 댓글이 존재하지 않습니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "commentId", description = "삭제할 댓글의 id"),
+    })
+    public ApiResponse<SuccessStatus> deleteComment(@PathVariable(name = "commentId")Long commentId){
+        return commentService.deleteComment(commentId);
+    }
+}

--- a/src/main/java/TubeSlice/tubeSlice/domain/comment/CommentRepository.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/comment/CommentRepository.java
@@ -1,0 +1,6 @@
+package TubeSlice.tubeSlice.domain.comment;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/TubeSlice/tubeSlice/domain/comment/CommentService.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/comment/CommentService.java
@@ -1,0 +1,45 @@
+package TubeSlice.tubeSlice.domain.comment;
+
+import TubeSlice.tubeSlice.domain.comment.dto.request.CommentRequestDto;
+import TubeSlice.tubeSlice.domain.comment.dto.response.CommentResponseDto;
+import TubeSlice.tubeSlice.domain.post.Post;
+import TubeSlice.tubeSlice.domain.user.User;
+import TubeSlice.tubeSlice.global.response.ApiResponse;
+import TubeSlice.tubeSlice.global.response.code.resultCode.ErrorStatus;
+import TubeSlice.tubeSlice.global.response.code.resultCode.SuccessStatus;
+import TubeSlice.tubeSlice.global.response.exception.handler.CommentHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentService {
+    private final CommentRepository commentRepository;
+
+    @Transactional
+    public CommentResponseDto.CommentResultDto createComment(CommentRequestDto.CommentCreateDto request, User user, Post post){
+        String content = request.getContent();
+
+        Comment comment = Comment.builder()
+                .content(content)
+                .user(user)
+                .post(post)
+                .build();
+
+        commentRepository.save(comment);
+
+        return CommentResponseDto.CommentResultDto.builder()
+                .commentId(comment.getId())
+                .build();
+    }
+
+    @Transactional
+    public ApiResponse<SuccessStatus> deleteComment(Long commentId){
+        Comment comment = commentRepository.findById(commentId).orElseThrow(()-> new CommentHandler(ErrorStatus.COMMENT_NOT_FOUND));
+        commentRepository.delete(comment);
+
+        return ApiResponse.onSuccess(SuccessStatus._OK);
+    }
+}

--- a/src/main/java/TubeSlice/tubeSlice/domain/comment/dto/request/CommentRequestDto.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/comment/dto/request/CommentRequestDto.java
@@ -1,0 +1,17 @@
+package TubeSlice.tubeSlice.domain.comment.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class CommentRequestDto {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class CommentCreateDto{
+        private String content;
+    }
+}

--- a/src/main/java/TubeSlice/tubeSlice/domain/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/comment/dto/response/CommentResponseDto.java
@@ -1,0 +1,15 @@
+package TubeSlice.tubeSlice.domain.comment.dto.response;
+
+import lombok.*;
+
+public class CommentResponseDto {
+
+    @Builder
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CommentResultDto{
+        private Long commentId;
+    }
+}

--- a/src/main/java/TubeSlice/tubeSlice/domain/keyword/dto/response/KeywordResponseDto.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/keyword/dto/response/KeywordResponseDto.java
@@ -6,7 +6,6 @@ public class KeywordResponseDto {
 
     @Builder
     @Getter
-    @Setter
     @NoArgsConstructor
     @AllArgsConstructor
     public static class KeywordResultDto{

--- a/src/main/java/TubeSlice/tubeSlice/domain/post/PostService.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/post/PostService.java
@@ -1,0 +1,18 @@
+package TubeSlice.tubeSlice.domain.post;
+
+import TubeSlice.tubeSlice.global.response.code.resultCode.ErrorStatus;
+import TubeSlice.tubeSlice.global.response.exception.handler.PostHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostService {
+    private final PostRepository postRepository;
+
+    public Post findPost(Long postId){
+        return postRepository.findById(postId).orElseThrow(()-> new PostHandler(ErrorStatus.POST_NOT_FOUND));
+    }
+}

--- a/src/main/java/TubeSlice/tubeSlice/global/response/code/resultCode/ErrorStatus.java
+++ b/src/main/java/TubeSlice/tubeSlice/global/response/code/resultCode/ErrorStatus.java
@@ -21,7 +21,10 @@ public enum ErrorStatus implements BaseErrorCode {
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST401", "게시글이 존재하지 않습니다."),
 
     // PostLike
-    POST_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "POSTLIKE401", "해당하는 좋아요가 존재하지 않습니다.");
+    POST_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "POSTLIKE401", "해당하는 좋아요가 존재하지 않습니다."),
+
+    // Comment
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT401", "해당하는 댓글이 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/TubeSlice/tubeSlice/global/response/exception/handler/CommentHandler.java
+++ b/src/main/java/TubeSlice/tubeSlice/global/response/exception/handler/CommentHandler.java
@@ -1,0 +1,10 @@
+package TubeSlice.tubeSlice.global.response.exception.handler;
+
+import TubeSlice.tubeSlice.global.response.code.BaseErrorCode;
+import TubeSlice.tubeSlice.global.response.exception.GeneralException;
+
+public class CommentHandler extends GeneralException {
+    public CommentHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}


### PR DESCRIPTION
# 구현 설명
---

## CommentController

- 댓글 생성하기 API
  - POST의 정보를 받아 해당 게시글에 댓글을 작성하는 API입니다.

```java
    @PostMapping("/posts/{postId}")
    @Operation(summary = "댓글 작성하기 API",description = "post의 id를 받아 댓글을 생성한 후 comment의 id(CommentResultDto)를 반환")
    public ApiResponse<CommentResponseDto.CommentResultDto> createComment(@PathVariable(name = "postId")Long postId, @RequestBody CommentRequestDto.CommentCreateDto request){
        User user = userService.findUser(1L);
        Post post = postService.findPost(postId);

        return ApiResponse.onSuccess(commentService.createComment(request, user, post));
    }
```
</BR>

- 댓글 삭제하기
  - 댓글의 id를 받아 해당 댓글을 삭제하는 API 입니다.

```java
    @DeleteMapping("/{commentId}")
    @Operation(summary = "댓글 삭제하기 API",description = "삭제할 comment의 id를 받아 삭제")
    public ApiResponse<SuccessStatus> deleteComment(@PathVariable(name = "commentId")Long commentId){
        return commentService.deleteComment(commentId);
    }
```