### PR TITLE
[Feat] 댓글 수정기능 구현

### DIFF
--- a/src/main/java/TubeSlice/tubeSlice/domain/comment/Comment.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/comment/Comment.java
@@ -4,14 +4,12 @@ import TubeSlice.tubeSlice.domain.post.Post;
 import TubeSlice.tubeSlice.domain.user.User;
 import TubeSlice.tubeSlice.global.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Table(name = "comment")
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/TubeSlice/tubeSlice/domain/comment/CommentController.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/comment/CommentController.java
@@ -54,4 +54,17 @@ public class CommentController {
     public ApiResponse<SuccessStatus> deleteComment(@PathVariable(name = "commentId")Long commentId){
         return commentService.deleteComment(commentId);
     }
+
+    @PatchMapping("/{commentId}")
+    @Operation(summary = "댓글 수정하기 API",description = "수정할 comment의 id를 받아 삭제")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMENT401", description = "수정할 댓글이 존재하지 않습니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMENT402", description = "수정할 권한이 존재하지 않습니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    public ApiResponse<SuccessStatus> updateComment(@RequestBody CommentRequestDto.CommentPatchDto request, @PathVariable(name = "commentId")Long commentId) {
+        User user = userService.findUser(1L); // 작성자 확인용 수정예정
+        return commentService.updateComment(request, commentId, user);
+    }
+
 }

--- a/src/main/java/TubeSlice/tubeSlice/domain/comment/CommentController.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/comment/CommentController.java
@@ -47,12 +47,14 @@ public class CommentController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMENT401", description = "삭제할 댓글이 존재하지 않습니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMENT402", description = "삭제할 권한이 존재하지 않습니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     @Parameters({
             @Parameter(name = "commentId", description = "삭제할 댓글의 id"),
     })
     public ApiResponse<SuccessStatus> deleteComment(@PathVariable(name = "commentId")Long commentId){
-        return commentService.deleteComment(commentId);
+        User user = userService.findUser(1L);
+        return commentService.deleteComment(user, commentId);
     }
 
     @PatchMapping("/{commentId}")

--- a/src/main/java/TubeSlice/tubeSlice/domain/comment/CommentService.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/comment/CommentService.java
@@ -36,8 +36,13 @@ public class CommentService {
     }
 
     @Transactional
-    public ApiResponse<SuccessStatus> deleteComment(Long commentId){
+    public ApiResponse<SuccessStatus> deleteComment(User user, Long commentId){
         Comment comment = commentRepository.findById(commentId).orElseThrow(()-> new CommentHandler(ErrorStatus.COMMENT_NOT_FOUND));
+
+        if(comment.getUser() != user){
+            throw new CommentHandler(ErrorStatus.COMMENT_FORBIDDEN);
+        }
+
         commentRepository.delete(comment);
 
         return ApiResponse.onSuccess(SuccessStatus._OK);

--- a/src/main/java/TubeSlice/tubeSlice/domain/comment/CommentService.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/comment/CommentService.java
@@ -42,4 +42,17 @@ public class CommentService {
 
         return ApiResponse.onSuccess(SuccessStatus._OK);
     }
+
+    @Transactional
+    public ApiResponse<SuccessStatus> updateComment(CommentRequestDto.CommentPatchDto request, Long commentId, User user){
+        Comment comment = commentRepository.findById(commentId).orElseThrow(()-> new CommentHandler(ErrorStatus.COMMENT_NOT_FOUND));
+        if(comment.getUser() != user){
+            throw new CommentHandler(ErrorStatus.COMMENT_FORBIDDEN);
+        }
+
+        comment.setContent(request.getContent());
+        commentRepository.save(comment);
+
+        return ApiResponse.onSuccess(SuccessStatus._OK);
+    }
 }

--- a/src/main/java/TubeSlice/tubeSlice/domain/comment/dto/request/CommentRequestDto.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/comment/dto/request/CommentRequestDto.java
@@ -14,4 +14,13 @@ public class CommentRequestDto {
     public static class CommentCreateDto{
         private String content;
     }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class CommentPatchDto{
+        private String content;
+    }
 }
+

--- a/src/main/java/TubeSlice/tubeSlice/global/response/code/resultCode/ErrorStatus.java
+++ b/src/main/java/TubeSlice/tubeSlice/global/response/code/resultCode/ErrorStatus.java
@@ -24,7 +24,8 @@ public enum ErrorStatus implements BaseErrorCode {
     POST_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "POSTLIKE401", "해당하는 좋아요가 존재하지 않습니다."),
 
     // Comment
-    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT401", "해당하는 댓글이 존재하지 않습니다.");
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT401", "해당하는 댓글이 존재하지 않습니다."),
+    COMMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "COMMENT402", "댓글 수정 혹은 삭제에 관한 권한이 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
# 구현 내용
---

- 댓글 수정 및  삭제는 작성자가 아닌 사람이 이용시 오류를 발생하도록 하였습니다. 현재 작성자로 판단하는 기준은 id가 1인 유저입니다.
- PathMapping을 처음 이용하였는데 잘 사용한건지는 모르겠습니다.

## CommentService

```java
    @Transactional
    public ApiResponse<SuccessStatus> updateComment(CommentRequestDto.CommentPatchDto request, Long commentId, User user){
        Comment comment = commentRepository.findById(commentId).orElseThrow(()-> new CommentHandler(ErrorStatus.COMMENT_NOT_FOUND));
        if(comment.getUser() != user){
            throw new CommentHandler(ErrorStatus.COMMENT_FORBIDDEN);
        }

        comment.setContent(request.getContent());
        commentRepository.save(comment);

        return ApiResponse.onSuccess(SuccessStatus._OK);
    }
```

삭제를 요청한 사람이 작성자가 아닐 경우 ErrorHandler를 발생시켰습니다.