### PR TITLE
[Feat] 나의 팔로워목록 가져오기 / 특정유저의 팔로워목록 가져오기

### DIFF
--- a/src/main/java/TubeSlice/tubeSlice/domain/user/UserController.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/user/UserController.java
@@ -102,4 +102,29 @@ public class UserController {
         return ApiResponse.onSuccess(userService.getFollowingList(me, user));
     }
 
+    @GetMapping("/me/follower")
+    @Operation(summary = "나의 팔로워 목록 가져오기 API",description = "FollowListDto 반환")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+    })
+    public ApiResponse<UserResponseDto.FollowListDto> getMyFollowerList(){
+        User me = userService.findUser(1L);
+        User user = userService.findUser(1L);
+
+        return ApiResponse.onSuccess(userService.getFollowerList(me, user));
+    }
+
+    @GetMapping("/{userId}/follower")
+    @Operation(summary = "특정유저의 팔로워 목록 가져오기 API",description = "FollowListDto 반환")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+    })
+    public ApiResponse<UserResponseDto.FollowListDto> getUserFollowerList(@PathVariable(name = "userId")Long userId) {
+        // 나의 기준 팔로잉 리스트 필요
+        User me = userService.findUser(1L);
+        // 보여질 팔로잉 리스트
+        User user = userService.findUser(userId);
+        return ApiResponse.onSuccess(userService.getFollowerList(me, user));
+    }
+
 }

--- a/src/main/java/TubeSlice/tubeSlice/domain/user/UserConverter.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/user/UserConverter.java
@@ -6,7 +6,7 @@ import TubeSlice.tubeSlice.domain.user.dto.response.UserResponseDto;
 import java.util.List;
 
 public class UserConverter {
-    public static UserResponseDto.FollowInfoDto toFollowInfoDto(List<Long> followingIdList, Follow follow){
+    public static UserResponseDto.FollowInfoDto toFollowingInfoDto(List<Long> followingIdList, Follow follow){
         boolean isFollowing = followingIdList.contains(follow.getReceiver().getId());
         User user = follow.getReceiver();
         return UserResponseDto.FollowInfoDto.builder()
@@ -18,10 +18,35 @@ public class UserConverter {
                 .build();
     }
 
-    public static UserResponseDto.FollowListDto toFollowListDto(List<Long> followingIdList, List<Follow> followingList
+    public static UserResponseDto.FollowListDto toFollowingListDto(List<Long> followingIdList, List<Follow> followingList
             , User user){
         List<UserResponseDto.FollowInfoDto> followInfoDtoList = followingList.stream()
-                .map(follow -> toFollowInfoDto(followingIdList, follow))
+                .map(follow -> toFollowingInfoDto(followingIdList, follow))
+                .toList();
+
+        return UserResponseDto.FollowListDto.builder()
+                .users(followInfoDtoList)
+                .followerNum(user.getFollowerList().size())
+                .followingNum(user.getFollowingList().size())
+                .build();
+    }
+
+    public static UserResponseDto.FollowInfoDto toFollowerInfoDto(List<Long> followingIdList, Follow follow){
+        boolean isFollowing = followingIdList.contains(follow.getSender().getId());
+        User user = follow.getSender();
+        return UserResponseDto.FollowInfoDto.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .profileUrl(user.getProfileUrl())
+                .introduction(user.getIntroduction())
+                .isFollowing(isFollowing)
+                .build();
+    }
+
+    public static UserResponseDto.FollowListDto toFollowerListDto(List<Long> followingIdList, List<Follow> followingList
+            , User user){
+        List<UserResponseDto.FollowInfoDto> followInfoDtoList = followingList.stream()
+                .map(follow -> toFollowerInfoDto(followingIdList, follow))
                 .toList();
 
         return UserResponseDto.FollowListDto.builder()

--- a/src/main/java/TubeSlice/tubeSlice/domain/user/UserService.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/user/UserService.java
@@ -57,13 +57,20 @@ public class UserService {
 
         return followingIdList;
     }
+
     public UserResponseDto.FollowListDto getFollowingList(User me, User user){
         List<Long> myFollowingIdList = getUserFollowingIdList(me);
         List<Follow> followList = user.getFollowingList();
 
-        return UserConverter.toFollowListDto(myFollowingIdList, followList, user);
+        return UserConverter.toFollowingListDto(myFollowingIdList, followList, user);
     }
 
+    public UserResponseDto.FollowListDto getFollowerList(User me, User user){
+        List<Long> myFollowingIdList = getUserFollowingIdList(me);
+        List<Follow> followList = user.getFollowerList();
+
+        return UserConverter.toFollowerListDto(myFollowingIdList, followList, user);
+    }
 
 }
 


### PR DESCRIPTION
# 구현 설명
---
- 이전 팔로잉목록 가져오기와 로직은 동일하지만 Converter에서의 함수가 달라집니다.
- 나의 팔로잉 목록과 비교할 대상이 receiver가 아닌 sender가 되기 때문입니다.
(팔로워는 나를 팔로어 한 사람 즉 Sender기준이기 때문)

## UserConverter

- 로직 설명을 조금 하자면 두번째 함수가 UserService에서 이용되는 함수입니다. 내기준 팔로잉 하는 유저의 id 목록과  보고싶은 팔로워목록을 변수로 받습니다.
- 이후 map과 lambda 함수를 이용하여 toFollowerInfoDto로 변환하여 Sender 기준으로 info를 작성 후 반환합니다.

```java
    public static UserResponseDto.FollowInfoDto toFollowerInfoDto(List<Long> followingIdList, Follow follow){
        boolean isFollowing = followingIdList.contains(follow.getSender().getId());
        User user = follow.getSender();
        return UserResponseDto.FollowInfoDto.builder()
                .userId(user.getId())
                .nickname(user.getNickname())
                .profileUrl(user.getProfileUrl())
                .introduction(user.getIntroduction())
                .isFollowing(isFollowing)
                .build();
    }

    public static UserResponseDto.FollowListDto toFollowerListDto(List<Long> followingIdList, List<Follow> followingList
            , User user){
        List<UserResponseDto.FollowInfoDto> followInfoDtoList = followingList.stream()
                .map(follow -> toFollowerInfoDto(followingIdList, follow))
                .toList();

        return UserResponseDto.FollowListDto.builder()
                .users(followInfoDtoList)
                .followerNum(user.getFollowerList().size())
                .followingNum(user.getFollowingList().size())
                .build();
    }
```

</br>

# 데이터베이스
---
- 확인 완료