### PR TITLE
[Feat] 마이페이지용 유저정보 가져오기

### DIFF
--- a/src/main/java/TubeSlice/tubeSlice/domain/user/UserController.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/user/UserController.java
@@ -25,8 +25,8 @@ import java.util.List;
 public class UserController {
     private final UserService userService;
 
-    @GetMapping("/me/posts")
-    @Operation(summary = "나의 게시글 목록 가져오기 API",description = "내가 작성한 게시글 목록 가져오기, PostInfoDto의 list를 반환")
+    @GetMapping("/me/mypage/posts")
+    @Operation(summary = "마이페이지용 나의 게시글 목록 가져오기 API",description = "PostInfoDto의 list를 반환")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
     })
@@ -37,8 +37,8 @@ public class UserController {
     }
 
 
-    @GetMapping("/{userId}/posts")
-    @Operation(summary = "특정유저의 게시글 목록 가져오기 API",description = "특정유저가 작성한 게시글 목록 가져오기, PostInfoDto의 list를 반환")
+    @GetMapping("/{userId}/mypage/posts")
+    @Operation(summary = "마이페이지용 특정유저의 게시글 목록 가져오기 API",description = "PostInfoDto의 list를 반환")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
     })
@@ -51,8 +51,8 @@ public class UserController {
         return ApiResponse.onSuccess(userService.getPostList(user));
     }
 
-    @GetMapping("/me/keywords")
-    @Operation(summary = "나의 키워드 목록 가져오기 API",description = "내가 작성한 키워드 목록 가져오기, KeywordResponseDto list를 반환")
+    @GetMapping("/me/mypage/keywords")
+    @Operation(summary = "마이페이지용 나의 키워드 목록 가져오기 API",description = "KeywordResponseDto list를 반환")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
     })
@@ -62,8 +62,8 @@ public class UserController {
         return ApiResponse.onSuccess(userService.getUserKeywordList(user));
     }
 
-    @GetMapping("/{userId}/keywords")
-    @Operation(summary = "특정유저의 키워드 목록 가져오기 API",description = "특정유저가 작성한 키워드 목록 가져오기, KeywordResponseDto list를 반환")
+    @GetMapping("/{userId}/mypage/keywords")
+    @Operation(summary = "마이페이지용 특정유저의 키워드 목록 가져오기 API",description = "KeywordResponseDto list를 반환")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
     })

--- a/src/main/java/TubeSlice/tubeSlice/domain/user/UserController.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/user/UserController.java
@@ -102,4 +102,15 @@ public class UserController {
         return ApiResponse.onSuccess(userService.getFollowingList(me, user));
     }
 
+    @GetMapping("/me/mypage")
+    @Operation(summary = "마이페이지용 유저정보 가져오기 API",description = "MypageUserInfoDto 반환")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+    })
+    public ApiResponse<UserResponseDto.MypageUserInfoDto> getMypageUserInfo(){
+        User user = userService.findUser(1L);
+
+        return ApiResponse.onSuccess(userService.getMypageUserInfo(user));
+    }
+
 }

--- a/src/main/java/TubeSlice/tubeSlice/domain/user/UserConverter.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/user/UserConverter.java
@@ -31,4 +31,14 @@ public class UserConverter {
                 .build();
     }
 
+    public static UserResponseDto.MypageUserInfoDto toMypageUserInfoDto(User user){
+        return UserResponseDto.MypageUserInfoDto.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .profileUrl(user.getProfileUrl())
+                .introduction(user.getIntroduction())
+                .followerNum(user.getFollowerList().size())
+                .followingNum(user.getFollowingList().size())
+                .build();
+    }
 }

--- a/src/main/java/TubeSlice/tubeSlice/domain/user/UserService.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/user/UserService.java
@@ -63,7 +63,15 @@ public class UserService {
 
         return UserConverter.toFollowListDto(myFollowingIdList, followList, user);
     }
-
-
+    public UserResponseDto.MypageUserInfoDto getMypageUserInfo(User user){
+        return UserResponseDto.MypageUserInfoDto.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .profileUrl(user.getProfileUrl())
+                .introduction(user.getIntroduction())
+                .followerNum(user.getFollowerList().size())
+                .followingNum(user.getFollowingList().size())
+                .build();
+    }
 }
 

--- a/src/main/java/TubeSlice/tubeSlice/domain/user/UserService.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/user/UserService.java
@@ -64,14 +64,7 @@ public class UserService {
         return UserConverter.toFollowListDto(myFollowingIdList, followList, user);
     }
     public UserResponseDto.MypageUserInfoDto getMypageUserInfo(User user){
-        return UserResponseDto.MypageUserInfoDto.builder()
-                .userId(user.getId())
-                .nickname(user.getNickname())
-                .profileUrl(user.getProfileUrl())
-                .introduction(user.getIntroduction())
-                .followerNum(user.getFollowerList().size())
-                .followingNum(user.getFollowingList().size())
-                .build();
+        return UserConverter.toMypageUserInfoDto(user);
     }
 }
 

--- a/src/main/java/TubeSlice/tubeSlice/domain/user/dto/response/UserResponseDto.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/user/dto/response/UserResponseDto.java
@@ -35,5 +35,16 @@ public class UserResponseDto {
         private Integer followerNum;
     }
 
-
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MypageUserInfoDto{
+        private Long userId;
+        private String nickname;
+        private String profileUrl;
+        private String introduction;
+        private Integer followingNum;
+        private Integer followerNum;
+    }
 }


### PR DESCRIPTION
# 구현 설명
---
- 해당 API는 그저 유저 정보를 담을 dto 생성 후 builder 이용하여 매핑해준 간단한 API입니다.

- 함수의 통일성을 위하여 간단한 builder도 Converter에서 진행하였습니다.

</br>

## UserConverter

```java
    public static UserResponseDto.MypageUserInfoDto toMypageUserInfoDto(User user){
        return UserResponseDto.MypageUserInfoDto.builder()
                .userId(user.getId())
                .nickname(user.getNickname())
                .profileUrl(user.getProfileUrl())
                .introduction(user.getIntroduction())
                .followerNum(user.getFollowerList().size())
                .followingNum(user.getFollowingList().size())
                .build();
    }
```

</br>

# 데이터베이스
---
```json
{
  "isSuccess": true,
  "code": "COMMON200",
  "message": "성공입니다.",
  "result": {
    "userId": 1,
    "nickname": "로그",
    "profileUrl": null,
    "introduction": "안녕하세요",
    "followingNum": 2,
    "followerNum": 3
  }
}
```
