### PR TITLE
[Refactor] 게시글 반환시 생성날짜 포맷 설정

### DIFF
--- a/src/main/java/TubeSlice/tubeSlice/TubeSliceApplication.java
+++ b/src/main/java/TubeSlice/tubeSlice/TubeSliceApplication.java
@@ -7,7 +7,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@OpenAPIDefinition(servers = {@Server(url = "https://tubeslice.site", description = "tubeslice")})
+//@OpenAPIDefinition(servers = {@Server(url = "https://tubeslice.site", description = "tubeslice")})
 @EnableJpaAuditing
 public class TubeSliceApplication {
 

--- a/src/main/java/TubeSlice/tubeSlice/domain/post/PostConverter.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/post/PostConverter.java
@@ -4,12 +4,43 @@ import TubeSlice.tubeSlice.domain.keyword.Keyword;
 import TubeSlice.tubeSlice.domain.post.dto.PostResponseDto;
 import TubeSlice.tubeSlice.domain.postKeyword.PostKeyword;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class PostConverter {
 
+    public static String toCreatedFormat(LocalDateTime createdAt){
+        LocalDateTime now = LocalDateTime.now();
+
+        Duration duration = Duration.between(createdAt, now);
+
+        long seconds = duration.getSeconds();
+        long minutes = duration.toMinutes();
+        long hours = duration.toHours();
+        long days = duration.toDays();
+
+        if(minutes < 1) {
+            return "방금 전";
+        }else if(minutes < 60){
+            return minutes + "분 전";
+        }else if (hours < 24) {
+            return "약 " + hours + "시간 전";
+        }else if(days < 2){
+            return "어제";
+        }else if (days < 7){
+            return days + "일 전";
+        }else {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일");
+            return createdAt.format(formatter);
+        }
+
+    }
+
     public static PostResponseDto.PostInfoDto toPostInfoDto(Post post){
+        String createdAt = toCreatedFormat(post.getCreatedAt());
         return PostResponseDto.PostInfoDto.builder()
                 .title(post.getTitle())
                 .postId(post.getId())
@@ -18,6 +49,7 @@ public class PostConverter {
                 .videoUrl(post.getVideoUrl())
                 .likeNum(post.getPostLikeList().size())
                 .commentNum(post.getCommentList().size())
+                .createdAt(createdAt)
                 .build();
     }
 

--- a/src/main/java/TubeSlice/tubeSlice/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/post/dto/PostResponseDto.java
@@ -18,5 +18,6 @@ public class PostResponseDto {
         private List<String> keywords;
         private Integer likeNum;
         private Integer commentNum;
+        private String createdAt;
     }
 }


### PR DESCRIPTION
# 구현 사항
---
- 게시글 목록 가져올 때, 생성날짜를 규칙에 따라 변환하는 함수 생성

```java
    public static String toCreatedFormat(LocalDateTime createdAt){
        LocalDateTime now = LocalDateTime.now();

        Duration duration = Duration.between(createdAt, now);

        long seconds = duration.getSeconds();
        long minutes = duration.toMinutes();
        long hours = duration.toHours();
        long days = duration.toDays();

        if(minutes < 1) {
            return "방금 전";
        }else if(minutes < 60){
            return minutes + "분 전";
        }else if (hours < 24) {
            return "약 " + hours + "시간 전";
        }else if(days < 2){
            return "어제";
        }else if (days < 7){
            return days + "일 전";
        }else {
            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일");
            return createdAt.format(formatter);
        }
```

</br>

# 데이터베이스

```json
{
  "isSuccess": true,
  "code": "COMMON200",
  "message": "성공입니다.",
  "result": [
    {
      "postId": 5,
      "title": "토큰? 세션?",
      "content": "왜 다들 JWT 토큰을 사용하는지 몰라서 한 번 정리해보았다.",
      "videoUrl": "https://www.youtube.com/watch?v=tosLBcAX1vk&t=276s&pp=ygUM7Yag7YGw7J20656A",
      "keywords": [],
      "likeNum": 0,
      "commentNum": 0,
      "createdAt": "5일 전"
    },
    {
      "postId": 4,
      "title": "세계 2차대전 왜?",
      "content": "세계 2차대전이 일어난 이유는 어떻고 이건 어떻고 저쩧고 왜 히틀러는 미대에 떨어져서는 이렇게 유대인을 학살한건",
      "videoUrl": "https://www.youtube.com/watch?v=oB3Vev8kcBY&pp=ygUQ7IS46rOEMuywqOuMgOyghA%3D%3D",
      "keywords": [
        "역사"
      ],
      "likeNum": 0,
      "commentNum": 2,
      "createdAt": "2024년 04월 28일"
    }
  ]
}
```