### PR TITLE
[Feat] 회원정보 수정 구현

### DIFF
--- a/src/main/java/TubeSlice/tubeSlice/domain/user/User.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/user/User.java
@@ -7,10 +7,7 @@ import TubeSlice.tubeSlice.domain.postLike.PostLike;
 import TubeSlice.tubeSlice.domain.userScript.UserScript;
 import TubeSlice.tubeSlice.global.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +15,7 @@ import java.util.List;
 @Entity
 @Table(name = "user")
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/TubeSlice/tubeSlice/domain/user/UserController.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/user/UserController.java
@@ -1,8 +1,10 @@
 package TubeSlice.tubeSlice.domain.user;
 
 import TubeSlice.tubeSlice.domain.post.dto.PostResponseDto;
+import TubeSlice.tubeSlice.domain.user.dto.request.UserRequestDto;
 import TubeSlice.tubeSlice.domain.user.dto.response.UserResponseDto;
 import TubeSlice.tubeSlice.global.response.ApiResponse;
+import TubeSlice.tubeSlice.global.response.code.resultCode.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -175,4 +177,13 @@ public class UserController {
 
         return ApiResponse.onSuccess(userService.getPostWithKeyword(user, keyword));
     }
+
+    @PatchMapping("/")
+    public ApiResponse<SuccessStatus> updateUserInfo(@AuthenticationPrincipal UserDetails details, @RequestBody UserRequestDto.UserInfoUpdateDto request){
+        Long userId = userService.getUserId(details);
+        User user = userService.findUser(userId);
+
+        return userService.updateUserInfo(user, request);
+    }
 }
+

--- a/src/main/java/TubeSlice/tubeSlice/domain/user/UserService.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/user/UserService.java
@@ -10,10 +10,13 @@ import TubeSlice.tubeSlice.domain.post.Post;
 import TubeSlice.tubeSlice.domain.post.PostConverter;
 import TubeSlice.tubeSlice.domain.post.dto.PostResponseDto;
 import TubeSlice.tubeSlice.domain.postKeyword.PostKeywordRepository;
+import TubeSlice.tubeSlice.domain.user.dto.request.UserRequestDto;
 import TubeSlice.tubeSlice.domain.user.dto.response.UserResponseDto;
 import TubeSlice.tubeSlice.global.jwt.UserDetailsImpl;
 import TubeSlice.tubeSlice.global.jwt.UserDetailsServiceImpl;
+import TubeSlice.tubeSlice.global.response.ApiResponse;
 import TubeSlice.tubeSlice.global.response.code.resultCode.ErrorStatus;
+import TubeSlice.tubeSlice.global.response.code.resultCode.SuccessStatus;
 import TubeSlice.tubeSlice.global.response.exception.handler.KeywordHandler;
 import TubeSlice.tubeSlice.global.response.exception.handler.UserHandler;
 import lombok.RequiredArgsConstructor;
@@ -101,6 +104,22 @@ public class UserService {
                 .toList();
 
         return PostConverter.toPostInfoDtoList(postWithKeywordList);
+    }
+
+    @Transactional
+    public ApiResponse<SuccessStatus> updateUserInfo(User user, UserRequestDto.UserInfoUpdateDto request){
+        if(request.getNickname() != null){
+            user.setNickname(request.getNickname());
+        }
+        if(request.getIntroduction() != null){
+            user.setIntroduction(request.getIntroduction());
+        }
+        if(request.getProfileUrl() != null){
+            user.setProfileUrl(request.getProfileUrl());
+        }
+
+        userRepository.save(user);
+        return ApiResponse.onSuccess(SuccessStatus._OK);
     }
 }
 

--- a/src/main/java/TubeSlice/tubeSlice/domain/user/dto/request/UserRequestDto.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/user/dto/request/UserRequestDto.java
@@ -1,7 +1,18 @@
 package TubeSlice.tubeSlice.domain.user.dto.request;
 
+import lombok.*;
+
 public class UserRequestDto {
 
-    String access_token;
+    @Builder
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserInfoUpdateDto{
+        private String nickname;
+        private String profileUrl;
+        private String introduction;
+    }
 
 }


### PR DESCRIPTION
# 구현 설명
---
- 닉네임, 자기소개, 이미지사진 수정하는 함수 구현

</br>

- PatchMapping을 이용하여 구현

```java
    @Transactional
    public ApiResponse<SuccessStatus> updateUserInfo(User user, UserRequestDto.UserInfoUpdateDto request){
        if(request.getNickname() != null){
            user.setNickname(request.getNickname());
        }
        if(request.getIntroduction() != null){
            user.setIntroduction(request.getIntroduction());
        }
        if(request.getProfileUrl() != null){
            user.setProfileUrl(request.getProfileUrl());
        }

        userRepository.save(user);
        return ApiResponse.onSuccess(SuccessStatus._OK);
    }
```

- 수정도 @Transactional이 필요하다는 사실을 알게되었습니다! 

</br>

데이터베이스 확인 완료.