### PR TITLE
[Feat] 마이페이지용 검색어 기반 게시글 목록 가져오기

### DIFF
--- a/src/main/java/TubeSlice/tubeSlice/domain/post/PostRepository.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/post/PostRepository.java
@@ -19,4 +19,13 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("SELECT DISTINCT p FROM Post p WHERE p.title LIKE %:search% OR p.content LIKE %:search%")
     List<Post> findPostsByTitleOrContent(String search);
+
+    @Query("SELECT p FROM Post p WHERE p.title LIKE %:title% AND p.user = :user")
+    Page<Post> findPostsByTitleAndUser(String title, User user, Pageable pageable);
+
+    @Query("SELECT p FROM Post p WHERE p.content LIKE %:content% AND p.user = :user")
+    Page<Post> findPostsByContentAndUser(String content, User user, Pageable pageable);
+
+    @Query("SELECT DISTINCT p FROM Post p WHERE p.title LIKE %:search% OR p.content LIKE %:search% AND p.user = :user")
+    Page<Post> findPostsByTitleOrContentAndUser(String search, User user, Pageable pageable);
 }

--- a/src/main/java/TubeSlice/tubeSlice/domain/user/UserController.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/user/UserController.java
@@ -223,4 +223,43 @@ public class UserController {
 
         return userService.deleteUser(user);
     }
+
+    @GetMapping("/me/mypage/search")
+    @Operation(summary = "마이페이지용 나의 검색 기반 게시글 가져오기 API",description = "type과 search를 받아 PostInfoListDto를 반환")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "POST402", description = "검색 타입이 올바르지 않습니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "type", description = "TITLE, CONTENT, BOTH"),
+            @Parameter(name = "search", description = "검색어"),
+            @Parameter(name = "page", description = "페이지 수"),
+            @Parameter(name = "size", description = "페이지 사이즈"),
+
+    })
+    public ApiResponse<PostResponseDto.PostInfoListDto> getMyPageSearch(@AuthenticationPrincipal UserDetails details, @RequestParam(name = "type")String type, @RequestParam(name = "search") String search, @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size){
+        Long userId = userService.getUserId(details);
+        User user = userService.findUser(userId);
+
+        return ApiResponse.onSuccess(userService.getMyPageSearch(user, type, search, page, size));
+    }
+
+    @GetMapping("/me/{userId}/search")
+    @Operation(summary = "마이페이지용 특정 유저의 검색 기반 게시글 가져오기 API",description = "type과 search를 받아 PostInfoListDto를 반환")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "POST402", description = "검색 타입이 올바르지 않습니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "type", description = "TITLE, CONTENT, BOTH"),
+            @Parameter(name = "search", description = "검색어"),
+            @Parameter(name = "page", description = "페이지 수"),
+            @Parameter(name = "size", description = "페이지 사이즈"),
+
+    })
+    public ApiResponse<PostResponseDto.PostInfoListDto> getUserPageSearch(@PathVariable(name = "userId")Long userId, @RequestParam(name = "type")String type, @RequestParam(name = "search") String search, @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size){
+        User user = userService.findUser(userId);
+
+        return ApiResponse.onSuccess(userService.getMyPageSearch(user, type, search, page, size));
+    }
 }

--- a/src/main/java/TubeSlice/tubeSlice/domain/user/UserService.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/user/UserService.java
@@ -19,6 +19,7 @@ import TubeSlice.tubeSlice.global.response.ApiResponse;
 import TubeSlice.tubeSlice.global.response.code.resultCode.ErrorStatus;
 import TubeSlice.tubeSlice.global.response.code.resultCode.SuccessStatus;
 import TubeSlice.tubeSlice.global.response.exception.handler.KeywordHandler;
+import TubeSlice.tubeSlice.global.response.exception.handler.PostHandler;
 import TubeSlice.tubeSlice.global.response.exception.handler.UserHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +32,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @Slf4j
@@ -146,6 +148,31 @@ public class UserService {
         userRepository.delete(user);
 
         return ApiResponse.onSuccess(SuccessStatus._OK);
+    }
+
+    public PostResponseDto.PostInfoListDto getMyPageSearch(User user, String type, String search, Integer page, Integer size){
+        List<Post> userPostList = user.getPostList();
+        if(userPostList == null){
+            return null;
+        }
+
+        if(type.equals("TITLE")){
+            Page<Post> postList = postRepository.findPostsByTitleAndUser(search, user, PageRequest.of(page, size));
+
+            return PostConverter.toPostInfoDtoList(postList);
+        } else if(type.equals("CONTENT")){
+            Page<Post> postList = postRepository.findPostsByContentAndUser(search, user,  PageRequest.of(page, size));
+
+            return PostConverter.toPostInfoDtoList(postList);
+        } else if(type.equals("BOTH")) {
+            Page<Post> postList = postRepository.findPostsByTitleOrContentAndUser(search, user ,PageRequest.of(page, size));
+
+            return PostConverter.toPostInfoDtoList(postList);
+        } else {
+            throw new PostHandler(ErrorStatus.POST_SEARCH_BAD_REQUEST);
+        }
+
+
     }
 }
 


### PR DESCRIPTION
# 구현 내용
---

## PostRepository

- 특정 유저의 게시물에서 검색을 진행하여야 하므로 User 객체도 추가해줬습니다.

```java
public interface PostRepository extends JpaRepository<Post, Long> {
    @Query("SELECT p FROM Post p WHERE p.title LIKE %:title% AND p.user = :user")
    Page<Post> findPostsByTitleAndUser(String title, User user, Pageable pageable);

    @Query("SELECT p FROM Post p WHERE p.content LIKE %:content% AND p.user = :user")
    Page<Post> findPostsByContentAndUser(String content, User user, Pageable pageable);

    @Query("SELECT DISTINCT p FROM Post p WHERE p.title LIKE %:search% OR p.content LIKE %:search% AND p.user = :user")
    Page<Post> findPostsByTitleOrContentAndUser(String search, User user, Pageable pageable);
}
```

</br>

## UserService

- 만들어둔 PostRepository 사용하였고, 컨버터는 원래 존재하던 PostInfoDtoList 함수를 이용하였습니다.

```java
    public PostResponseDto.PostInfoListDto getMyPageSearch(User user, String type, String search, Integer page, Integer size){
        List<Post> userPostList = user.getPostList();
        if(userPostList == null){
            return null;
        }

        if(type.equals("TITLE")){
            Page<Post> postList = postRepository.findPostsByTitleAndUser(search, user, PageRequest.of(page, size));

            return PostConverter.toPostInfoDtoList(postList);
        } else if(type.equals("CONTENT")){
            Page<Post> postList = postRepository.findPostsByContentAndUser(search, user,  PageRequest.of(page, size));

            return PostConverter.toPostInfoDtoList(postList);
        } else if(type.equals("BOTH")) {
            Page<Post> postList = postRepository.findPostsByTitleOrContentAndUser(search, user ,PageRequest.of(page, size));

            return PostConverter.toPostInfoDtoList(postList);
        } else {
            throw new PostHandler(ErrorStatus.POST_SEARCH_BAD_REQUEST);
        }
    }
```
