### PR TITLE
[Refactor] 회원정보 수정 (이미지)

### DIFF
--- a/src/main/java/TubeSlice/tubeSlice/domain/image/ImageRepository.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/image/ImageRepository.java
@@ -1,0 +1,6 @@
+package TubeSlice.tubeSlice.domain.image;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+}

--- a/src/main/java/TubeSlice/tubeSlice/domain/user/UserService.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/user/UserService.java
@@ -3,6 +3,8 @@ package TubeSlice.tubeSlice.domain.user;
 
 import TubeSlice.tubeSlice.domain.follow.Follow;
 import TubeSlice.tubeSlice.domain.follow.FollowRepository;
+import TubeSlice.tubeSlice.domain.image.Image;
+import TubeSlice.tubeSlice.domain.image.ImageRepository;
 import TubeSlice.tubeSlice.domain.keyword.Keyword;
 import TubeSlice.tubeSlice.domain.keyword.KeywordConverter;
 import TubeSlice.tubeSlice.domain.keyword.KeywordRepository;
@@ -46,6 +48,7 @@ public class UserService {
     private final PostRepository postRepository;
     private final UserDetailsServiceImpl userDetailsService;
     private final FollowRepository followRepository;
+    private final ImageRepository imageRepository;
 
     public Long getUserId(UserDetails user){
         String username = user.getUsername();
@@ -136,8 +139,9 @@ public class UserService {
         if(request.getIntroduction() != null){
             user.setIntroduction(request.getIntroduction());
         }
-        if(request.getProfileUrl() != null){
-            user.setProfileUrl(request.getProfileUrl());
+        if(request.getImageId() != null){
+            Image image = imageRepository.getReferenceById(request.getImageId());
+            user.setProfileUrl(image.getUrl());
         }
 
         userRepository.save(user);

--- a/src/main/java/TubeSlice/tubeSlice/domain/user/dto/request/UserRequestDto.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/user/dto/request/UserRequestDto.java
@@ -11,7 +11,7 @@ public class UserRequestDto {
     @AllArgsConstructor
     public static class UserInfoUpdateDto{
         private String nickname;
-        private String profileUrl;
+        private Long imageId;
         private String introduction;
     }
 


### PR DESCRIPTION
# 수정 사항
---

- S3를 통한 이미지 업로드 기능이 추가됨에 따라 유저 정보에서 프로필이미지 수정시 profileUrl을 받도록 진행한 것과 달리 해당 이미지의 id값을 받아 수정하는 것으로 진행하였습니다.

## UserRequestDto

```java
public class UserRequestDto {

    @Builder
    @Getter
    @Setter
    @NoArgsConstructor
    @AllArgsConstructor
    public static class UserInfoUpdateDto{
        private String nickname;
        private Long imageId;
        private String introduction;
    }

}
```

- 기존과 같이 profileUrl을 받는 것이 아닌 생성된 이미지의 id를 받도록 설정