### PR TITLE
[Feat] 키워드 별로 스크립트 목록 가져오기

### DIFF
--- a/src/main/java/TubeSlice/tubeSlice/domain/scriptKeyword/ScriptKeywordRepository.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/scriptKeyword/ScriptKeywordRepository.java
@@ -10,4 +10,5 @@ public interface ScriptKeywordRepository extends JpaRepository<ScriptKeyword, Lo
 
     ScriptKeyword findByKeywordAndUserScriptId(Keyword keyword, Long userScriptId);
     List<ScriptKeyword> findByUserScriptId(Long userScriptId);
+    List<ScriptKeyword> findAllByKeywordName(String keyword);
 }

--- a/src/main/java/TubeSlice/tubeSlice/domain/userScript/UserScriptController.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/userScript/UserScriptController.java
@@ -132,5 +132,17 @@ public class UserScriptController {
         return ApiResponse.onSuccess(userScriptService.getScriptKeywordList(user));
     }
 
+    @GetMapping("/list")
+    @Operation(summary = "키워드 별로 스크립트 목록 가져오기",description = "키워드 별로 저장한 스크립트 목록 가져오기")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USERSCRIPT01", description = "스크립트 정보를 찾을 수 없습니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    public ApiResponse<UserScriptResponse.UserScriptResponseListDto> getScriptByKeyword(@AuthenticationPrincipal UserDetails details,
+                                                                                        @RequestParam("keyword") String keyword){
+        Long userId = userService.getUserId(details);
+        User user = userService.findUser(userId);
 
+        return ApiResponse.onSuccess(userScriptService.getScriptListByKeyword(user, keyword));
+    }
 }

--- a/src/main/java/TubeSlice/tubeSlice/domain/userScript/UserScriptService.java
+++ b/src/main/java/TubeSlice/tubeSlice/domain/userScript/UserScriptService.java
@@ -1,6 +1,8 @@
 package TubeSlice.tubeSlice.domain.userScript;
 
 import TubeSlice.tubeSlice.domain.script.Script;
+import TubeSlice.tubeSlice.domain.scriptKeyword.ScriptKeyword;
+import TubeSlice.tubeSlice.domain.scriptKeyword.ScriptKeywordRepository;
 import TubeSlice.tubeSlice.domain.scriptKeyword.ScriptKeywordService;
 import TubeSlice.tubeSlice.domain.text.Text;
 import TubeSlice.tubeSlice.domain.text.TextConverter;
@@ -19,8 +21,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -29,6 +33,7 @@ import java.util.List;
 public class UserScriptService {
 
     private final UserScriptRepository userScriptRepository;
+    private final ScriptKeywordRepository scriptKeywordRepository;
     private final TextRepository textRepository;
 
     private final TextService textService;
@@ -139,5 +144,20 @@ public class UserScriptService {
         List<UserScript> userScriptList = userScriptRepository.findAllByUser(user);
 
         return UserScriptConverter.toUserScriptKeywordList(userScriptList);
+    }
+
+    public UserScriptResponse.UserScriptResponseListDto getScriptListByKeyword(User user, String keyword){
+
+        List<ScriptKeyword> scriptKeywords = scriptKeywordRepository.findAllByKeywordName(keyword);
+
+        if (scriptKeywords == null){
+            throw new UserScriptHandler(ErrorStatus.USER_SCRIPT_NOT_FOUND2);
+        }
+
+        List<UserScript> userScriptList = scriptKeywords.stream()
+                .map(ScriptKeyword::getUserScript)
+                .collect(Collectors.toList());
+
+        return UserScriptConverter.toUserScriptList(userScriptList);
     }
 }


### PR DESCRIPTION
# UserScriptService
- 키워드로 유저 스크립트 찾아와서 뿌림

```java
public UserScriptResponse.UserScriptResponseListDto getScriptListByKeyword(User user, String keyword){

        List<ScriptKeyword> scriptKeywords = scriptKeywordRepository.findAllByKeywordName(keyword);

        if (scriptKeywords == null){
            throw new UserScriptHandler(ErrorStatus.USER_SCRIPT_NOT_FOUND2);
        }

        List<UserScript> userScriptList = scriptKeywords.stream()
                .map(ScriptKeyword::getUserScript)
                .collect(Collectors.toList());

        return UserScriptConverter.toUserScriptList(userScriptList);
    }
``` 